### PR TITLE
Feat: add generic error component to the project

### DIFF
--- a/demo/nerdlets/nr1-community-demo-nerdlet/index.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/index.js
@@ -8,6 +8,7 @@ const componentList = [
   // { name: 'AccountDropdown', category: 'Components' },
   { name: 'DetailPanel', category: 'Components' },
   { name: 'EmptyState', category: 'Components' },
+  { name: 'GenericError', category: 'Components' },
   { name: 'Timeline', category: 'Components' },
   { name: 'NerdGraphError', category: 'Components' },
   { name: 'timeRangeToNrql', category: 'Utilities' }

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { NerdGraphQuery } from 'nr1';
+import { NerdGraphError } from '@/../dist';
+import CodeHighlight from '../../../shared/components/CodeHighlight';
+
+export default class NerdGraphErrorBasicDemo extends React.Component {
+  static propTypes = {
+    header: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      enableLiveEditing: false
+    };
+  }
+
+  renderHighlight() {
+    const { enableLiveEditing } = this.state;
+    const scope = {
+      NerdGraphQuery,
+      NerdGraphError
+    };
+    const code = `
+() => { // Enclosed in an arrow function so we can show you query and variables
+  const query = \`
+    query($id: Int!) {
+      actor {
+          account(id: $id) {
+              name
+          }
+      }
+    }
+  \`;
+
+  const variables = {
+    id: 1111111111111 // Not a real account id, triggers the error
+  };
+
+  return (
+    <NerdGraphQuery query={query} variables={variables}>
+      {({ loading, data, error }) => {
+        if (error) {
+          return <NerdGraphError error={error} />;
+        }
+        return null;
+      }}
+    </NerdGraphQuery>
+  );
+}
+    `;
+    return (
+      <CodeHighlight
+        scope={scope}
+        code={code}
+        language="jsx"
+        use="react-live"
+        enableLiveEditing={enableLiveEditing}
+      />
+    );
+  }
+
+  render() {
+    const { header } = this.props;
+
+    return (
+      <div className="example-container">
+        <h3 id={header.id}>{header.text}</h3>
+        <p>
+          Demonstrate the default behavior of displaying captured errors in an Apollo-based GraphQL error.
+        </p>
+
+        <div className="example-container-content">
+          {this.renderHighlight()}
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
@@ -20,36 +20,14 @@ export default class GenericErrorBasicDemo extends React.Component {
   renderHighlight() {
     const { enableLiveEditing } = this.state;
     const scope = {
-      NerdGraphQuery,
       GenericError
     };
     const code = `
-() => { // Enclosed in an arrow function so we can show you query and variables
-  const query = \`
-    query($id: Int!) {
-      actor {
-          account(id: $id) {
-              name
-          }
-      }
-    }
-  \`;
-
-  const variables = {
-    id: 1111111111111 // Not a real account id, triggers the error
-  };
-
-  return (
-    <NerdGraphQuery query={query} variables={variables}>
-      {({ loading, data, error }) => {
-        if (error) {
-          return <GenericError error={error} />;
-        }
-        return null;
-      }}
-    </NerdGraphQuery>
-  );
-}
+    <GenericError
+    error="Generic Error"
+    hideIcon
+    errorDescription="This is a description of the error"
+  />
     `;
     return (
       <CodeHighlight

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/Examples/Basic.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { NerdGraphQuery } from 'nr1';
-import { NerdGraphError } from '@/../dist';
+import { GenericError } from '@/../dist';
 import CodeHighlight from '../../../shared/components/CodeHighlight';
 
-export default class NerdGraphErrorBasicDemo extends React.Component {
+export default class GenericErrorBasicDemo extends React.Component {
   static propTypes = {
     header: PropTypes.object
   };
@@ -21,7 +21,7 @@ export default class NerdGraphErrorBasicDemo extends React.Component {
     const { enableLiveEditing } = this.state;
     const scope = {
       NerdGraphQuery,
-      NerdGraphError
+      GenericError
     };
     const code = `
 () => { // Enclosed in an arrow function so we can show you query and variables
@@ -43,7 +43,7 @@ export default class NerdGraphErrorBasicDemo extends React.Component {
     <NerdGraphQuery query={query} variables={variables}>
       {({ loading, data, error }) => {
         if (error) {
-          return <NerdGraphError error={error} />;
+          return <GenericError error={error} />;
         }
         return null;
       }}
@@ -69,7 +69,7 @@ export default class NerdGraphErrorBasicDemo extends React.Component {
       <div className="example-container">
         <h3 id={header.id}>{header.text}</h3>
         <p>
-          Demonstrate the default behavior of displaying captured errors in an Apollo-based GraphQL error.
+          Demonstrate the default behavior of displaying captured errors.
         </p>
 
         <div className="example-container-content">

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/index.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/index.js
@@ -1,41 +1,136 @@
-export { GenericError } from './GenericError';
-
 import React from 'react';
-import PropTypes from 'prop-types';
 
-export class GenericError extends React.Component {
-  static propTypes = {
-    heading: PropTypes.string
-  };
+// NR1
+import { Grid, GridItem, Button } from 'nr1';
 
+// Local components
+import PropsTable from '../../shared/components/PropsTable';
+import InstallAndUse from '../../shared/components/InstallAndUse';
+import BasicExample from './examples/basic';
+
+// Page data
+import meta from '@/components/GenericError/meta.json';
+
+const page = {
+  title: 'Generic Error',
+  subtitle: 'A helper component for formatting and displaying generic errors.'
+};
+
+const pageHeaders = {
+  title: {
+    text: 'Generic Error',
+    id: 'title',
+    hierarchy: 0
+  },
+  examples: {
+    text: 'Examples',
+    id: 'examples',
+    hierarchy: 0
+  },
+  basicExample: {
+    text: 'Basic',
+    id: 'basic',
+    hierarchy: 1
+  },
+  installationAndUsage: {
+    text: 'Installation and Usage',
+    id: 'installation-and-usage',
+    hierarchy: 0
+  },
+  properties: {
+    text: 'Properties',
+    id: 'properties',
+    hierarchy: 0
+  }
+};
+
+export default class TimelineDemo extends React.Component {
   constructor(props) {
     super(props);
-
-    this.handleButtonClick = this.handleButtonClick.bind(this);
+    this.state = {
+      showSidebar: true
+    };
   }
 
+  renderSidebar() {
+    const { showSidebar } = this.state;
+
+    if (!showSidebar) {
+      return null;
+    }
+
+    return (
+      <GridItem columnSpan={3} className="secondary-grid-item">
+        <div className="secondary-nav-container">
+          <h6 className="secondary-nav-container-header">On this page</h6>
+          <ul className="secondary-nav">{this.renderHeaders()}</ul>
+        </div>
+        <Button
+          className="readme-link"
+          to="https://github.com/newrelic/nr1-community/blob/master/src/components/GenericError/README.md"
+        >
+          View {pageHeaders.title.text} README
+        </Button>
+      </GridItem>
+    );
+  }
+
+  renderHeaders() {
+    const pageHeaderIds = Object.keys(pageHeaders);
+
+    return pageHeaderIds.map(pageHeaderId => {
+      const hierarchy = pageHeaders[pageHeaderId].hierarchy;
+      const id = pageHeaders[pageHeaderId].id;
+      const text = pageHeaders[pageHeaderId].text;
+
+      return (
+        <li
+          key={pageHeaderId}
+          className={`secondary-nav-item ${
+            hierarchy === 1 ? 'child-header' : ''
+          }`}
+        >
+          <a href={`#${id}`}>{text}</a>
+        </li>
+      );
+    });
+  }
 
   render() {
-    // const {  } = this.props;
-    debugger
+    const { showSidebar } = this.state;
+
     return (
-        <div className={[styles['ng-error-container'], open].join(' ')}>
-        <div className={styles['ng-error-body-header']} onClick={this.onClick}>
-          {/* TO DO - Display a count of graphql Errors? */}
-          <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
-          <h5 className={styles['ng-error-title']}>{message}</h5>
-          {showDetails && (
-            <a href="#" className={styles['ng-error-details-button']}>
-              {expanded ? 'Hide details' : 'View details'}
-            </a>
-          )} 
-        </div>
-        {showDetails && (
-          <div className={styles['ng-error-details']}>
-            {errorDetails({ error })}
-          </div>
-        )}
-      </div>
+      <Grid spacingType={[Grid.SPACING_TYPE.OMIT, Grid.SPACING_TYPE.NONE]}>
+        <GridItem
+          columnSpan={showSidebar ? 9 : 12}
+          collapseGapAfter
+          className="primary-grid-item"
+        >
+          <h1 id={pageHeaders.title.id}>{pageHeaders.title.text}</h1>
+          <p className="lead-paragraph">{page.subtitle}</p>
+
+          <hr />
+
+          <h2 id={pageHeaders.examples.id}>{pageHeaders.examples.text}</h2>
+          <p>{meta.description}</p>
+
+          {/* Code Samples */}
+          <BasicExample header={pageHeaders.basicExample} />
+
+          {/* Installation/Usage */}
+          <h2 id={pageHeaders.installationAndUsage.id}>
+            {pageHeaders.installationAndUsage.text}
+          </h2>
+          <InstallAndUse type="component" name="GenericError" />
+
+          {/* Props */}
+          <h2 id={pageHeaders.properties.id}>{pageHeaders.properties.text}</h2>
+          <PropsTable meta={meta} />
+        </GridItem>
+
+        {/* Sidebar */}
+        {this.renderSidebar()}
+      </Grid>
     );
   }
 }

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/index.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/GenericError/index.js
@@ -1,0 +1,41 @@
+export { GenericError } from './GenericError';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class GenericError extends React.Component {
+  static propTypes = {
+    heading: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleButtonClick = this.handleButtonClick.bind(this);
+  }
+
+
+  render() {
+    // const {  } = this.props;
+    debugger
+    return (
+        <div className={[styles['ng-error-container'], open].join(' ')}>
+        <div className={styles['ng-error-body-header']} onClick={this.onClick}>
+          {/* TO DO - Display a count of graphql Errors? */}
+          <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
+          <h5 className={styles['ng-error-title']}>{message}</h5>
+          {showDetails && (
+            <a href="#" className={styles['ng-error-details-button']}>
+              {expanded ? 'Hide details' : 'View details'}
+            </a>
+          )} 
+        </div>
+        {showDetails && (
+          <div className={styles['ng-error-details']}>
+            {errorDetails({ error })}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/demo/nerdlets/nr1-community-demo-nerdlet/pages/index.js
+++ b/demo/nerdlets/nr1-community-demo-nerdlet/pages/index.js
@@ -1,6 +1,7 @@
 export { default as AccountDropdown } from './AccountDropdown';
 export { default as DetailPanel } from './DetailPanel';
 export { default as EmptyState } from './EmptyState';
+export { default as GenericError } from './GenericError';
 export { default as Timeline } from './Timeline';
 export { default as NerdGraphError } from './NerdGraphError';
 export { default as timeRangeToNrql } from './timeRangeToNrql';

--- a/src/components/GenericError/README.md
+++ b/src/components/GenericError/README.md
@@ -1,0 +1,23 @@
+# Generic Error
+
+## Description
+
+## Installation
+
+1. Install nr1-community
+
+  ```bash
+  npm i @newrelic/nr1-community
+  ```
+  
+2. Add the styles for the component to the top of your stylesheet (probably named `styles.scss`):
+
+  ```scss
+  @import '~@newrelic/nr1-community/dist/index.css';
+  ```
+
+## Usage
+
+```jsx
+import { NerdGraphError } from '@newrelic/nr1-community';
+```

--- a/src/components/GenericError/index.js
+++ b/src/components/GenericError/index.js
@@ -1,0 +1,41 @@
+export { GenericError } from './GenericError';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class EmptyState extends React.Component {
+  static propTypes = {
+    heading: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleButtonClick = this.handleButtonClick.bind(this);
+  }
+
+
+  render() {
+    const { } = this.props;
+
+    return (
+        <div className={[styles['ng-error-container'], open].join(' ')}>
+        <div className={styles['ng-error-body-header']} onClick={this.onClick}>
+          {/* TO DO - Display a count of graphql Errors? */}
+          <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
+          <h5 className={styles['ng-error-title']}>{message}</h5>
+          {showDetails && (
+            <a href="#" className={styles['ng-error-details-button']}>
+              {expanded ? 'Hide details' : 'View details'}
+            </a>
+          )}
+        </div>
+        {showDetails && (
+          <div className={styles['ng-error-details']}>
+            {errorDetails({ error })}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/GenericError/index.js
+++ b/src/components/GenericError/index.js
@@ -1,40 +1,90 @@
-export { GenericError } from './GenericError';
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export class EmptyState extends React.Component {
+import { Icon, Button } from 'nr1';
+
+import styles from './styles.scss';
+
+const _defaultDetails = function({ error }) {
+  // eslint-disable-next-line no-unused-vars
+  const { graphQLErrors, message, stack } = error;
+  return (
+    <ul className={styles['ng-error-item-contents']}>
+      <li className={styles['ng-error-item-contents-item']}>
+        <span className={styles.key}>Stack</span>
+        <span className={styles.value}>{JSON.stringify(stack)}</span>
+      </li>
+      {graphQLErrors.length > 0 &&
+        graphQLErrors.map((gqlError, i) => {
+          if (gqlError) {
+            return (
+              <li key={i} className={styles['ng-error-item-contents-item']}>
+                <span className={styles.key}>{`GraphQL Error ${i + 1}`}:</span>
+                <span className={styles.value}>{gqlError.message}</span>
+              </li>
+            );
+          }
+          return null;
+        })}
+    </ul>
+  );
+};
+_defaultDetails.propTypes = {
+  error: PropTypes.object
+};
+
+export class GenericError extends React.Component {
   static propTypes = {
-    heading: PropTypes.string
+    error: PropTypes.object,
+    showDetails: PropTypes.bool,
+    errorDetails: PropTypes.func
+  };
+
+  static defaultProps = {
+    showDetails: true,
+    errorDetails: _defaultDetails
   };
 
   constructor(props) {
     super(props);
-
-    this.handleButtonClick = this.handleButtonClick.bind(this);
+    this.state = {
+      expanded: false
+    };
+    this.onClick = this.onClick.bind(this);
   }
 
+  onClick() {
+    this.setState(prevState => ({
+      expanded: !prevState.expanded
+    }));
+  }
 
   render() {
-    const { } = this.props;
+    const { error, showDetails, errorDetails } = this.props;
+    const { expanded } = this.state;
+
+    // eslint-disable-next-line no-unused-vars
+    const { graphQLErrors, message, stack } = error;
+
+    const open = expanded ? styles['ng-error-item-expanded'] : '';
 
     return (
-        <div className={[styles['ng-error-container'], open].join(' ')}>
+      <div className={[styles['ng-error-container'], open].join(' ')}>
         <div className={styles['ng-error-body-header']} onClick={this.onClick}>
           {/* TO DO - Display a count of graphql Errors? */}
           <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
-          <h5 className={styles['ng-error-title']}>{message}</h5>
-          {showDetails && (
+          <h5 className={styles['ng-error-title']}>{'GenericError'}</h5>
+          {/* {showDetails && (
             <a href="#" className={styles['ng-error-details-button']}>
               {expanded ? 'Hide details' : 'View details'}
             </a>
-          )}
+          )} */}
         </div>
-        {showDetails && (
+        {/* {showDetails && (
           <div className={styles['ng-error-details']}>
             {errorDetails({ error })}
           </div>
-        )}
+        )} */}
       </div>
     );
   }

--- a/src/components/GenericError/index.js
+++ b/src/components/GenericError/index.js
@@ -1,90 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Icon, Button } from 'nr1';
+import { Icon } from 'nr1';
 
 import styles from './styles.scss';
 
-const _defaultDetails = function({ error }) {
-  // eslint-disable-next-line no-unused-vars
-  const { graphQLErrors, message, stack } = error;
-  return (
-    <ul className={styles['ng-error-item-contents']}>
-      <li className={styles['ng-error-item-contents-item']}>
-        <span className={styles.key}>Stack</span>
-        <span className={styles.value}>{JSON.stringify(stack)}</span>
-      </li>
-      {graphQLErrors.length > 0 &&
-        graphQLErrors.map((gqlError, i) => {
-          if (gqlError) {
-            return (
-              <li key={i} className={styles['ng-error-item-contents-item']}>
-                <span className={styles.key}>{`GraphQL Error ${i + 1}`}:</span>
-                <span className={styles.value}>{gqlError.message}</span>
-              </li>
-            );
-          }
-          return null;
-        })}
-    </ul>
-  );
-};
-_defaultDetails.propTypes = {
-  error: PropTypes.object
-};
-
 export class GenericError extends React.Component {
   static propTypes = {
-    error: PropTypes.object,
-    showDetails: PropTypes.bool,
-    errorDetails: PropTypes.func
+    error: PropTypes.string,
+    hideIcon: PropTypes.bool,
+    errorDescription: PropTypes.string
   };
 
   static defaultProps = {
-    showDetails: true,
-    errorDetails: _defaultDetails
+    error: 'Error:',
+    errorDescription: '',
+    hideIcon: false
   };
 
   constructor(props) {
     super(props);
-    this.state = {
-      expanded: false
-    };
-    this.onClick = this.onClick.bind(this);
-  }
-
-  onClick() {
-    this.setState(prevState => ({
-      expanded: !prevState.expanded
-    }));
   }
 
   render() {
-    const { error, showDetails, errorDetails } = this.props;
-    const { expanded } = this.state;
-
-    // eslint-disable-next-line no-unused-vars
-    const { graphQLErrors, message, stack } = error;
-
-    const open = expanded ? styles['ng-error-item-expanded'] : '';
+    const { error, hideIcon, errorDescription } = this.props;
 
     return (
       <div className={[styles['ng-error-container'], open].join(' ')}>
         <div className={styles['ng-error-body-header']} onClick={this.onClick}>
-          {/* TO DO - Display a count of graphql Errors? */}
-          <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
-          <h5 className={styles['ng-error-title']}>{'GenericError'}</h5>
-          {/* {showDetails && (
-            <a href="#" className={styles['ng-error-details-button']}>
-              {expanded ? 'Hide details' : 'View details'}
-            </a>
-          )} */}
+          {!hideIcon && (
+            <Icon type={Icon.TYPE.INTERFACE__STATE__CRITICAL} color="#bf0015" />
+          )}
+          <h5 className={`${styles['ng-error-title']} ${hideIcon ? styles['ng-no-icon'] : ''}`}>{error}:</h5>
+          <p className={styles['ng-error-description']}>{errorDescription}</p>
         </div>
-        {/* {showDetails && (
-          <div className={styles['ng-error-details']}>
-            {errorDetails({ error })}
-          </div>
-        )} */}
       </div>
     );
   }

--- a/src/components/GenericError/meta.json
+++ b/src/components/GenericError/meta.json
@@ -1,0 +1,12 @@
+{
+  "name": "NerdGraphError",
+  "description": "Display generic errors in a more consumable, useful pattern.",
+  "props": [
+    {
+      "name": "error",
+      "type": "object",
+      "description": "Error object from the underlying generic error.",
+      "default": "null"
+    }
+  ]
+}

--- a/src/components/GenericError/meta.json
+++ b/src/components/GenericError/meta.json
@@ -1,11 +1,23 @@
 {
-  "name": "NerdGraphError",
+  "name": "GenericError",
   "description": "Display generic errors in a more consumable, useful pattern.",
   "props": [
     {
       "name": "error",
-      "type": "object",
-      "description": "Error object from the underlying generic error.",
+      "type": "string",
+      "description": "Error title for the generic error.",
+      "default": "Error"
+    },
+    {
+      "name": "hideIcon",
+      "type": "boolean",
+      "description": "Controls whether the icon is shown or hidden for the generic error",
+      "default": "false"
+    },
+    {
+      "name": "errorDescription",
+      "type": "string",
+      "description": "Error description for the generic error",
       "default": "null"
     }
   ]

--- a/src/components/GenericError/styles.scss
+++ b/src/components/GenericError/styles.scss
@@ -1,0 +1,75 @@
+.ng-error-container {
+  background-color: #fcf2f3;
+  border-radius: 4px;
+  transition: all .1s cubic-bezier(.25, .46, .45, .94);
+  border: 1px solid #fae1e4;
+
+  &:hover {
+    background-color: rgba(#bf0015, .08);
+
+    .ng-error-details {
+      border-color: rgba(#bf0015, .08);
+    }
+  }
+}
+
+
+.ng-error-body-header {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.ng-error-title {
+  display: inline-block;
+  flex-grow: 1;
+  margin-left: 8px;
+  font-size: 14px;
+  color: #bf0015;
+}
+
+.ng-error-details-button {
+  padding: 0 2px;
+  color: #bf0015;
+  border-bottom: 1px dotted rgba(#bf0015, .35);
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.ng-error-details {
+  display: none;
+  background-color: #fff;
+  border: 2px solid #fcf2f3;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  padding: 10px 12px;
+  transition: all .1s cubic-bezier(.25, .46, .45, .94);
+
+  .ng-error-container & ul {
+    padding: 0 0 0 16px;
+    font-size: 12px;
+    line-height: 19px;
+    color: #54000a;
+    font-family: 'Fira code', monospace;
+
+    .key {
+      margin-right: 4px;
+    }
+  }
+
+  .ng-error-container & p {
+    font-size: 12px;
+    line-height: 19px;
+    color: #54000a;
+  }
+
+  .ng-error-item-expanded & {
+    display: block;
+  }
+}

--- a/src/components/GenericError/styles.scss
+++ b/src/components/GenericError/styles.scss
@@ -26,10 +26,21 @@
 
 .ng-error-title {
   display: inline-block;
-  flex-grow: 1;
   margin-left: 8px;
   font-size: 14px;
   color: #bf0015;
+}
+div.ng-error-container div.ng-error-body-header p.ng-error-description {
+    text-align: left;
+    flex-grow: 1;
+    margin: 2px 0 0 5px;
+    font-size: 14px;
+    color: rgba(#bf0015, .5);
+    font-weight: normal;
+  }
+
+.ng-no-icon {
+  margin-left: 0;
 }
 
 .ng-error-details-button {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 export { AccountDropdown } from './AccountDropdown';
 export { DetailPanel } from './DetailPanel';
 export { EmptyState } from './EmptyState';
+export { GenericError } from './GenericError';
 export { Timeline } from './Timeline';
 export { Funnel } from './Funnel';
 export { NerdGraphError } from './NerdGraphError';


### PR DESCRIPTION
I saw that there’s an open issue (#61) for adding a generic error component to the project and I thought I’d take a swing at it. I hope this is helpful, but at the very least it was good practice. I’m open to any changes or feedback and will keep my eyes peeled for any updates. Here’s gist of the component:

<img width="654" alt="Screen Shot 2020-04-24 at 7 01 26 PM" src="https://user-images.githubusercontent.com/39764444/80263255-0c527600-865e-11ea-8c99-13f601c43c9f.png">

Here are the props available on the component:
- `error`: Displays an error heading/title in bold at the beginning of the component
- `errorDescription`: Which displays a more verbose description after the title (limited to the width of the component body)
- `hideIcon`: which hides the icon, which is visible by default
